### PR TITLE
Don't create or mention maketest.g

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ m4/ltsugar.m4
 m4/ltversion.m4
 Makefile
 Makefile.in
-maketest.g
 missing
 src/pkgconfig.h
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ To create the documentation:
 
 To run the test files
 
-    gap maketest.g
     gap tst/testall.g
     
 ## Update

--- a/makedoc.g
+++ b/makedoc.g
@@ -4,13 +4,12 @@
 # This file is a script which compiles the package manual.
 #
 
-if fail = LoadPackage("AutoDoc", "2016.02.16") then
-    Error("AutoDoc version 2016.02.16 or newer is required.");
+if fail = LoadPackage("AutoDoc", ">= 2019.04.10") then
+    Error("AutoDoc 2019.04.10 or newer is required");
 fi;
 
 AutoDoc( 
         rec(
-            maketest := rec( commands := [ "LoadPackage(\"CddInterface\");" ] ),
             scaffold := rec( entities := [ "GAP4", "homalg" ] ),
             autodoc := rec( files := [ "doc/intro.autodoc" ] ),
             extract_examples := rec( units := "Single" )


### PR DESCRIPTION
There seems to be no point in doing this *and* using `extract_examples`, and I'd really like to get rid of the whole `maketest.g` construct in AutoDoc at some point in the (probably distant) future.

But perhaps I am missing something. In that case, I'd like to learn more about whatever I missed. E.g. perhaps the homalg CI setup requires `maketest.g` and does not yet support `tst/testall.g`? I'd then argue that this CI setup should be improved ;-).