### PR TITLE
Cygwin fixes

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/sh -ex
 #
-# Regenerate configure from configure.ac. Requires GNU autoconf.
-set -ex
-autoconf -Wall -f
+# This file is part of the build system of a GAP kernel extension.
+# Requires GNU autoconf, GNU automake and GNU libtool.
+#
+autoreconf -vif `dirname "$0"`

--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ AS_IF([test "x$with_cddlib" != "xyes"],[
   CDD_CPPFLAGS="-I$with_cddlib/include/cdd -I$with_cddlib/include/cddlib -I$with_cddlib/include"
   CDD_LDFLAGS="-L$with_cddlib/lib -lcddgmp"
 ],[
-  CDD_CPPFLAGS="-I/usr/include/cdd"
+  CDD_CPPFLAGS="-I/usr/include/cdd -I/usr/include/cddlib"
   CDD_LDFLAGS="-lcddgmp"
 ])
 AC_SUBST(CDD_CPPFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ AC_INIT([CddInterface], [package])
 AC_CONFIG_SRCDIR([src/CddInterface.c])
 AC_CONFIG_MACRO_DIR([m4])
 m4_include([m4/find_gap.m4])
-
+AC_CONFIG_AUX_DIR([cnf])
 dnl ##
 dnl ## Set the language
 dnl ##
@@ -43,6 +43,18 @@ AS_IF([test "x$with_cddlib" != "xyes"],[
   CDD_CPPFLAGS="-I/usr/include/cdd -I/usr/include/cddlib"
   CDD_LDFLAGS="-lcddgmp"
 ])
+
+dnl ##
+dnl ## Detect Cygwin, as then we need to link against gmp
+dnl ##
+AC_CANONICAL_HOST
+
+case $host_os in
+  *cygwin* ) CDD_LDFLAGS="$CDD_LDFLAGS -lgmp";;
+         * ) ;;
+esac
+
+
 AC_SUBST(CDD_CPPFLAGS)
 AC_SUBST(CDD_LDFLAGS)
 


### PR DESCRIPTION
This adds some fixes for building which are required for cygwin.

In brief:

* cygwin stores cddlib's header files in /usr/include/cddlib, so add that to the list of places we always look.
* cygwin needs "-lgmp" passing when linking (I can go into more details, but basically on windows you need to link explicitly to any libraries you use, not libraries which also link to those libraries). This requires a bigger change, as I need to add the stuff which lets me detect which OS we are running on.

With these changes, CddInterface will build on cygwin, so can be distributed in the windows release of GAP.

 