### PR TITLE
Rename install.sh to prerequisites.sh

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,10 +33,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: 'Install additional dependencies'
-        run: |
-          sudo apt-get update
-          sudo apt-get install libcdd-dev
       - uses: gap-actions/setup-gap@v2
         with:
           GAPBRANCH: ${{ matrix.gap-branch }}
@@ -53,11 +49,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - name: 'Install additional dependencies'
-        run: |
-          sudo apt-get update
-          sudo apt-get install libcdd-dev
       - uses: gap-actions/setup-gap@v2
       - uses: gap-actions/build-pkg-docs@v1
         with:

--- a/install.sh
+++ b/install.sh
@@ -9,56 +9,12 @@ else
     gap_path=../..
 fi
 
-current_dir=$(pwd)
-cd $gap_path
-
-if [ -f "sysinfo.gap" ]; then
-    echo "Ok, thanks I found the gap installation."
-else
-    echo "ERROR: It seems that the given location for gap installation is not correct."
-    echo "The given location is $(pwd)."
-    exit 1
-fi
-
-cd $current_dir
-
-echo "## Setting variables"
-echo "I am now in $(pwd)"
-
-cddlib_VERSION=0.94m
-#cddlib_SHA256=?
-cddlib_BASE=cddlib-${cddlib_VERSION}
-cddlib_TAR=${cddlib_BASE}.tar.gz
-cddlib_URL=https://github.com/cddlib/cddlib/releases/download/${cddlib_VERSION}/${cddlib_TAR}
-
-echo
-echo "##"
-echo "## downloading ${cddlib_TAR}"
-echo "##"
-
-rm -rf cddlib*
-rm -rf current_cddlib
-etc/download.sh ${cddlib_URL}
-tar xvf ${cddlib_TAR}
-ln -sf $current_dir/${cddlib_BASE} $current_dir/current_cddlib
-rm -rf ${cddlib_TAR}
-
-echo "##"
-echo "## compiling cddlib ${cddlib_VERSION}"
-echo "##"
-
-cd ${cddlib_BASE}
-mkdir build
-./bootstrap
-./configure --prefix=$(pwd)/build
-make
-make install
+./prerequisites.sh ${gap_path}
 
 echo "##"
 echo "## compiling cdd interface"
 echo "##"
 
-cd $current_dir
 ./autogen.sh
 ./configure --with-gaproot=${gap_path} --with-cddlib=$(pwd)/current_cddlib/build
 make

--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e # abort upon error
+
+if [ "$#" -ge 1 ]; then
+    gap_path=$1
+    shift
+else
+    gap_path=../..
+fi
+
+current_dir=$PWD
+cd $gap_path
+
+if [ -f "sysinfo.gap" ]; then
+    echo "Ok, thanks I found the gap installation."
+else
+    echo "ERROR: It seems that the given location for gap installation is not correct."
+    echo "The given location is $PWD."
+    exit 1
+fi
+
+cd $current_dir
+
+echo "## Setting variables"
+echo "I am now in $PWD"
+
+cddlib_VERSION=0.94m
+#cddlib_SHA256=?
+cddlib_BASE=cddlib-${cddlib_VERSION}
+cddlib_TAR=${cddlib_BASE}.tar.gz
+cddlib_URL=https://github.com/cddlib/cddlib/releases/download/${cddlib_VERSION}/${cddlib_TAR}
+
+echo
+echo "##"
+echo "## downloading ${cddlib_TAR}"
+echo "##"
+
+rm -rf cddlib*
+rm -rf current_cddlib
+etc/download.sh ${cddlib_URL}
+tar xvf ${cddlib_TAR}
+ln -sf $current_dir/${cddlib_BASE} $current_dir/current_cddlib
+rm -rf ${cddlib_TAR}
+
+echo "##"
+echo "## compiling cddlib ${cddlib_VERSION}"
+echo "##"
+
+cd ${cddlib_BASE}
+mkdir build
+./bootstrap
+./configure --prefix=$PWD/build
+make
+make install


### PR DESCRIPTION
This way, GAP's BuildPackages.sh script will automatically execute it, meaning that cddlib will end up being available for more users than without this.

The GH actions CI scripts also use this, so no need for libcdd-dev anymore.

Contains PR #33. Closes PR #33