### PR TITLE
Include compiled.h instead of src/compiled.h

### DIFF
--- a/src/CddInterface.c
+++ b/src/CddInterface.c
@@ -2,7 +2,7 @@
  * CddInterface: Gap interface to Cdd package
  */
 
-#include "src/compiled.h" /* GAP headers */
+#include "compiled.h" // GAP headers
 
 #include "setoper.h"
 #include "cdd.h"


### PR DESCRIPTION
This will help in the future with GAP packages for Linux distros
