### PR TITLE
Various build system tweaks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,9 +33,10 @@ AC_ARG_WITH([cddlib],
     [], [with_cddlib=yes])
 AS_IF([test "x$with_cddlib" = "xno"], [AC_MSG_ERROR([cddlib is required and cannot be disabled])])
 AS_IF([test "x$with_cddlib" != "xyes"],[
-  # Debian and Ubuntu put the headers into PREFIX/include/cdd, while on other
-  # systems, the headers are directly in PREFIX/include/ -- so we just add
-  # both to the CPPFLAGS
+  # Debian and Ubuntu put the headers into PREFIX/include/cdd, while on
+  # e.g. homebrew the headers are in PREFIX/include/cddlib. Finally in
+  # some cases, the headers are directly in PREFIX/include/ -- so we
+  # just add all three to the CPPFLAGS
   AS_IF([test -d "$with_cddlib"],[],[AC_MSG_ERROR([the cddlib path is not a directory])])
   CDD_CPPFLAGS="-I$with_cddlib/include/cdd -I$with_cddlib/include/cddlib -I$with_cddlib/include"
   CDD_LDFLAGS="-L$with_cddlib/lib -lcddgmp -lgmp"

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,16 @@ AC_ARG_WITH([cddlib],
     [AS_HELP_STRING([--with-cddlib=<path>], [specify the path of cdd installation])],
     [], [with_cddlib=yes])
 AS_IF([test "x$with_cddlib" = "xno"], [AC_MSG_ERROR([cddlib is required and cannot be disabled])])
+
+# if no path was given. as a special consideration, detect if the user has cddlib
+# installed via Homebrew (on macOS), and if so, use that
+AS_IF([test "x$with_cddlib" = "xyes"],[
+  AS_IF([command -v brew >/dev/null 2>&1],[
+    AC_MSG_NOTICE([BREW detected])
+    with_cddlib=$(brew --prefix)
+  ])
+])
+
 AS_IF([test "x$with_cddlib" != "xyes"],[
   # Debian and Ubuntu put the headers into PREFIX/include/cdd, while on
   # e.g. homebrew the headers are in PREFIX/include/cddlib. Finally in

--- a/m4/find_gap.m4
+++ b/m4/find_gap.m4
@@ -55,6 +55,7 @@ AC_DEFUN([FIND_GAP],
   if test "x$GAParch" != "x"; then
     GAPARCH=$GAParch
   fi
+  AC_MSG_RESULT($GAPARCH)
 
   if test "x$GAPARCH" = "xUnknown" ; then
     echo ""


### PR DESCRIPTION
- configure.ac: update comment
- m4/find_gap.m4: balance 'checking for GAP architecture' msg
- configure.ac: find cddlib installed by Homebreak


Perhaps you could make a new release of the package, too?