### PR TITLE
Update CI setup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
           - stable-4.12
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Install additional dependencies'
         run: |
           sudo apt-get update
@@ -40,7 +40,9 @@ jobs:
       - uses: gap-actions/build-pkg@v1
       - uses: gap-actions/run-pkg-tests@v2
       - uses: gap-actions/process-coverage@v2
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   # The documentation job
   manual:
@@ -48,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Install additional dependencies'
         run: |
           sudo apt-get update
@@ -58,7 +60,7 @@ jobs:
         with:
           use-latex: 'true'
       - name: 'Upload documentation'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: manual
           path: ./doc/manual.pdf


### PR DESCRIPTION
Note that for code coverage reporting to really work, you need to set
`CODECOV_TOKEN` in the GitHub repository or organization settings. See
<https://docs.codecov.com/docs/adding-the-codecov-token> for instructions.

Without it, it will remain broken as it is right now.
