### PR TITLE
Switch from compiled.h to gap_all.h

### DIFF
--- a/src/CddInterface.c
+++ b/src/CddInterface.c
@@ -2,7 +2,7 @@
  * CddInterface: Gap interface to Cdd package
  */
 
-#include "compiled.h" // GAP headers
+#include "gap_all.h" // GAP headers
 #include "config.h"
 
 #if HAVE_CDDLIB_SETOPER_H == 1


### PR DESCRIPTION
This is the preferred header since GAP 4.12 (which this package
requires anyway).
