### PR TITLE
CI: disable cron schedule

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - master
   pull_request:
-  schedule:
-    # Runs at night every day
-    - cron: '0 2 * * *'
 
 # the `concurrency` settings ensure that not too many CI jobs run in parallel
 concurrency:


### PR DESCRIPTION
@kamalsaleh @mohamed-barakat it seems the CI support for this repository was disabled at some point -- my guess this was done automatically because (a) there is a cron schedule in the config, and (b) there weren't any changes to the repo for an extended period of time.

I suggest to remove the cron schedule (done by this PR) and re-enable the CI tests.