### PR TITLE
Update `PackageInfo.g` and CI suite

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,30 +18,27 @@ concurrency:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }}
+    name: ${{ matrix.gap-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        gap-branch:
-          - master
-          - stable-4.14
-          - stable-4.13
-          - stable-4.12
+        gap-version:
+          - 'devel'
+          - '4.15'
+          - '4.14'
+          - '4.13'
+          - '4.12'
 
     steps:
-      - uses: actions/checkout@v4
-      - name: 'Install additional dependencies'
-        run: |
-          sudo apt-get update
-          sudo apt-get install libcdd-dev
-      - uses: gap-actions/setup-gap@v2
+      - uses: actions/checkout@v6
+      - uses: gap-actions/setup-gap@v3
         with:
-          GAPBRANCH: ${{ matrix.gap-branch }}
-      - uses: gap-actions/build-pkg@v1
-      - uses: gap-actions/run-pkg-tests@v2
-      - uses: gap-actions/process-coverage@v2
-      - uses: codecov/codecov-action@v5
+          gap-version: ${{ matrix.gap-version }}
+      - uses: gap-actions/build-pkg@v3
+      - uses: gap-actions/run-pkg-tests@v4
+      - uses: gap-actions/process-coverage@v3
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -51,18 +48,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - name: 'Install additional dependencies'
-        run: |
-          sudo apt-get update
-          sudo apt-get install libcdd-dev
-      - uses: gap-actions/setup-gap@v2
-      - uses: gap-actions/build-pkg-docs@v1
+      - uses: actions/checkout@v6
+      - uses: gap-actions/setup-gap@v3
+      - uses: gap-actions/build-pkg-docs@v2
         with:
           use-latex: 'true'
       - name: 'Upload documentation'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: manual
+          archive: false
           path: ./doc/manual.pdf
           if-no-files-found: error

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -77,6 +77,7 @@ Dependencies := rec(
   GAP := ">= 4.12",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ] ],
   SuggestedOtherPackages := [ ],
+  NeededSystemPackages := rec( Ubuntu := [["libcdd-dev"]], Homebrew := [["cddlib"]] ),
   ExternalConditions := [ ],
 ),
 


### PR DESCRIPTION
This PR updates all actions used in the CI workflow to the latest version, and makes use of the new `Dependencies.NeededSystemPackages` field in `PackageInfo.g` to simplify the CI workflow(s).

Remarks:
- I also updated the "manuals" portion of the CI script. For packages under the `gap-packages` organisation, this job has been split into a separate workflow.
- The `Dependencies.ExternalConditions` is empty. Since this package relies on external software, it probably shouldn't be.